### PR TITLE
Update mountpoint URL in fstab.yaml

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,5 @@
 mountpoints:
   /:
-    url: https://dita-franklin-worker.adobeaem.workers.dev/your-user-name/your-repo-name/main/docs
+    url: https://guides.adobe.com/eds-workers/your-user-name/your-repo-name/main/docs
     type: markup
 


### PR DESCRIPTION
Update the fstab.yaml worker URL

## Description

Update the fstab.yaml worker URL

## Related Issue

The old URL got migrated